### PR TITLE
Revert "docs: Try dash triplets"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,4 @@
----
 title: Ralph Hightower @ github.io [Gateway — Website]
----
 
 author:
   name: Ralph Hightower 


### PR DESCRIPTION
Reverts RalphHightower/RalphHightower.github.io#79
That didn't work. 