### PR TITLE
[build](info): MetricsActions(extended description)

### DIFF
--- a/.github/workflows/MetricsActions.yml
+++ b/.github/workflows/MetricsActions.yml
@@ -55,5 +55,6 @@ jobs:
           plugin_stargazers_charts_type: classic
           plugin_stargazers_days: 14
           plugin_stargazers_worldmap: yes
+          plugin_stargazers_worldmap_token: ${{secrets.GOOGLE_MAP_TOKEN}}
           plugin_traffic: yes
           repositories_forks: yes


### PR DESCRIPTION
plugin_stargazers_worldmap_token: ${{secrets.GOOGLE_MAP_TOKEN}}

Obtaining a Google Maps API token
Some features like plugin_stagazers_worldmap require a Google Geocoding API token. Follow instructions from their [documentation](https://developers.google.com/maps/documentation/geocoding/get-api-key ) for more informations.

💳 A billing account is required to get a token. However a recurring [monthly credit](https://developers.google.com/maps/billing-credits#monthly ) is offered which means you should not be charged if you don't exceed the free quota.

It is advised to set the quota limit at 1200 requests per day

Use at your own risk, metrics and its authors cannot be held responsible for anything charged.

